### PR TITLE
Allow custom definitions of in-word characters

### DIFF
--- a/src/main/java/org/neosearch/stringsearcher/SimpleStringSearcherBuilder.java
+++ b/src/main/java/org/neosearch/stringsearcher/SimpleStringSearcherBuilder.java
@@ -1,6 +1,7 @@
 package org.neosearch.stringsearcher;
 
 import java.util.Collection;
+import java.util.function.Predicate;
 
 /**
  * Builder class to create a StringMatcher instance. Several algorithms can be
@@ -112,6 +113,18 @@ public class SimpleStringSearcherBuilder {
      */
     public SimpleStringSearcherBuilder stopOnHit() {
         this.stringSearcherBuilder.stopOnHit();
+        return this;
+    }
+
+    /**
+     * Configure the Trie to match keywords based on the given predicate which
+     * returns true for all characters that are considered in-word characters.
+     *
+     * @return This builder.
+     */
+    public SimpleStringSearcherBuilder setIsInWordCharacter(
+            Predicate<Character> isInWordCharacter) {
+        this.stringSearcherBuilder.setInWordCharacters(isInWordCharacter);
         return this;
     }
 

--- a/src/main/java/org/neosearch/stringsearcher/StringSearcherBuilder.java
+++ b/src/main/java/org/neosearch/stringsearcher/StringSearcherBuilder.java
@@ -5,7 +5,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Map.Entry;
 import java.util.Queue;
-
+import java.util.function.Predicate;
 import org.neosearch.stringsearcher.trie.Trie;
 
 /**
@@ -164,6 +164,17 @@ public class StringSearcherBuilder<T> {
      */
     public StringSearcherBuilder<T> onlyWholeWordsWhiteSpaceSeparated() {
         this.config.setOnlyWholeWordsWhiteSpaceSeparated(true);
+        return this;
+    }
+
+    /**
+     * Configure the Trie to match whole keywords based on the given predicate which
+     * returns true for all characters that are considered in-word characters.
+     *
+     * @return This builder.
+     */
+    public StringSearcherBuilder<T> setInWordCharacters(Predicate<Character> isInWordCharacter) {
+        this.config.setIsInWordCharacter(isInWordCharacter);
         return this;
     }
 

--- a/src/main/java/org/neosearch/stringsearcher/StringSearcherConfig.java
+++ b/src/main/java/org/neosearch/stringsearcher/StringSearcherConfig.java
@@ -1,5 +1,7 @@
 package org.neosearch.stringsearcher;
 
+import java.util.function.Predicate;
+
 /**
  * Configures options for matching strings.
  * 
@@ -11,11 +13,9 @@ public class StringSearcherConfig {
 
     private boolean allowOverlaps = true;
 
-    private boolean onlyWholeWords = false;
-
-    private boolean onlyWholeWordsWhiteSpaceSeparated = false;
-
     private boolean stopOnHit = false;
+
+    private Predicate<Character> isInWordCharacter = null;
 
     /**
      * Returns true if the matching should be case insensitive.
@@ -42,7 +42,8 @@ public class StringSearcherConfig {
 
     /**
      * Configures it he StringSearcher should stop on hit.
-     * @param stopOnHit true, if the StringSearch should stop on hit. False 
+     * 
+     * @param stopOnHit true, if the StringSearch should stop on hit. False
      */
     public void setStopOnHit(boolean stopOnHit) {
         this.stopOnHit = stopOnHit;
@@ -56,20 +57,24 @@ public class StringSearcherConfig {
         this.allowOverlaps = allowOverlaps;
     }
 
-    public boolean isOnlyWholeWords() {
-        return onlyWholeWords;
-    }
-
     public void setOnlyWholeWords(boolean onlyWholeWords) {
-        this.onlyWholeWords = onlyWholeWords;
-    }
-
-    public boolean isOnlyWholeWordsWhiteSpaceSeparated() {
-        return onlyWholeWordsWhiteSpaceSeparated;
+        this.isInWordCharacter = onlyWholeWords ? ch -> Character.isAlphabetic(ch) : null;
     }
 
     public void setOnlyWholeWordsWhiteSpaceSeparated(boolean onlyWholeWordsWhiteSpaceSeparated) {
-        this.onlyWholeWordsWhiteSpaceSeparated = onlyWholeWordsWhiteSpaceSeparated;
+        this.isInWordCharacter = onlyWholeWordsWhiteSpaceSeparated ? ch -> !Character.isWhitespace(ch) : null;
+    }
+
+    public void setIsInWordCharacter(Predicate<Character> isInWordCharacter) {
+        this.isInWordCharacter = isInWordCharacter;
+    }
+
+    public Predicate<Character> isInWordCharacter() {
+        return this.isInWordCharacter;
+    }
+
+    public boolean isOnlyWholeWords() {
+        return isInWordCharacter != null;
     }
 
 }

--- a/src/main/java/org/neosearch/stringsearcher/StringSearcherConfig.java
+++ b/src/main/java/org/neosearch/stringsearcher/StringSearcherConfig.java
@@ -42,7 +42,6 @@ public class StringSearcherConfig {
 
     /**
      * Configures it he StringSearcher should stop on hit.
-     * 
      * @param stopOnHit true, if the StringSearch should stop on hit. False
      */
     public void setStopOnHit(boolean stopOnHit) {

--- a/src/main/java/org/neosearch/stringsearcher/StringSearcherConfig.java
+++ b/src/main/java/org/neosearch/stringsearcher/StringSearcherConfig.java
@@ -62,7 +62,8 @@ public class StringSearcherConfig {
     }
 
     public void setOnlyWholeWordsWhiteSpaceSeparated(boolean onlyWholeWordsWhiteSpaceSeparated) {
-        this.isInWordCharacter = onlyWholeWordsWhiteSpaceSeparated ? ch -> !Character.isWhitespace(ch) : null;
+        this.isInWordCharacter =
+                onlyWholeWordsWhiteSpaceSeparated ? ch -> !Character.isWhitespace(ch) : null;
     }
 
     public void setIsInWordCharacter(Predicate<Character> isInWordCharacter) {

--- a/src/main/java/org/neosearch/stringsearcher/trie/Trie.java
+++ b/src/main/java/org/neosearch/stringsearcher/trie/Trie.java
@@ -46,7 +46,7 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
      * Used by the builder to add a text search keyword with a emit payload.
      *
      * @param keyword The search term to add to the list of search terms.
-     * @param emit the payload to emit for this search term.
+     * @param emit    the payload to emit for this search term.
      * @throws NullPointerException if the keyword is null.
      */
     public void addSearchString(String keyword, T emit) {
@@ -120,10 +120,8 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
         return tokens;
     }
 
-    private Token<T> createFragment(final Emit<T> emit, final String text,
-            final int lastCollectedPosition) {
-        return new FragmentToken<T>(text.substring(lastCollectedPosition + 1,
-                emit == null ? text.length() : emit.getStart()));
+    private Token<T> createFragment(final Emit<T> emit, final String text, final int lastCollectedPosition) {
+        return new FragmentToken<T>(text.substring(lastCollectedPosition + 1, emit == null ? text.length() : emit.getStart()));
     }
 
     private Token<T> createMatch(Emit<T> emit, String text) {
@@ -144,13 +142,12 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
      * Tokenizes the specified text by using a custom EmitHandler and returns the
      * emitted outputs.
      * 
-     * @param text The character sequence to tokenize.
+     * @param text        The character sequence to tokenize.
      * @param emitHandler The emit handler that will be used to parse the text.
      * @return A collection of emits.
      */
     @SuppressWarnings("unchecked")
-    public Collection<Emit<T>> parseText(final CharSequence text,
-            final StatefulEmitHandler<T> emitHandler) {
+    public Collection<Emit<T>> parseText(final CharSequence text, final StatefulEmitHandler<T> emitHandler) {
         parseText(text, (EmitHandler<T>) emitHandler);
 
         final List<Emit<T>> collectedEmits = emitHandler.getEmits();
@@ -159,8 +156,7 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
             removePartialMatches(text, collectedEmits);
         }
         if (!trieConfig.isAllowOverlaps()) {
-            IntervalTree intervalTree =
-                    new IntervalTree((List<Intervalable>) (List<?>) collectedEmits);
+            IntervalTree intervalTree = new IntervalTree((List<Intervalable>) (List<?>) collectedEmits);
             intervalTree.removeOverlaps((List<Intervalable>) (List<?>) collectedEmits);
         }
 
@@ -183,7 +179,7 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
      * Tokenizes the specified text by using a custom EmitHandler and returns the
      * emitted outputs.
      * 
-     * @param text The character sequence to tokenize.
+     * @param text        The character sequence to tokenize.
      * @param emitHandler The emit handler that will be used to parse the text.
      */
 
@@ -236,9 +232,8 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
 
                 if (payloads != null && !payloads.isEmpty()) {
                     for (final Payload<T> payload : payloads) {
-                        final Emit<T> emit =
-                                new Emit<>(position - payload.getKeyword().length() + 1, position,
-                                        payload.getKeyword(), payload.getData());
+                        final Emit<T> emit = new Emit<>(position - payload.getKeyword().length() + 1, position,
+                                payload.getKeyword(), payload.getData());
                         if (trieConfig.isOnlyWholeWords()) {
                             if (!isPartialMatch(text, emit)) {
                                 return emit;
@@ -255,14 +250,11 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
     }
 
     private boolean isPartialMatch(final CharSequence searchText, final Emit<T> emit) {
-        return (emit.getStart() != 0
-                && trieConfig.isInWordCharacter().test(searchText.charAt(emit.getStart() - 1)))
-                || (emit.getEnd() + 1 != searchText.length() && trieConfig.isInWordCharacter()
-                        .test(searchText.charAt(emit.getEnd() + 1)));
+        return (emit.getStart() != 0 && trieConfig.isInWordCharacter().test(searchText.charAt(emit.getStart() - 1)))
+                || (emit.getEnd() + 1 != searchText.length() && trieConfig.isInWordCharacter().test(searchText.charAt(emit.getEnd() + 1)));
     }
 
-    private void removePartialMatches(final CharSequence searchText,
-            final List<Emit<T>> collectedEmits) {
+    private void removePartialMatches(final CharSequence searchText, final List<Emit<T>> collectedEmits) {
 
         final RemoveElementPredicate<Emit<T>> predicate = new RemoveElementPredicate<Emit<T>>() {
 
@@ -318,19 +310,15 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
         return this;
     }
 
-    private boolean storeEmits(final int position, final State<T> currentState,
-            final EmitHandler<T> emitHandler) {
+    private boolean storeEmits(final int position, final State<T> currentState, final EmitHandler<T> emitHandler) {
         boolean emitted = false;
         final Collection<Payload<T>> payloads = currentState.emit();
 
         // TODO: The check for empty might be superfluous.
         if (payloads != null && !payloads.isEmpty()) {
             for (final Payload<T> payload : payloads) {
-                emitted =
-                        emitHandler
-                                .emit(new Emit<T>(position - payload.getKeyword().length() + 1,
-                                        position, payload.getKeyword(), payload.getData()))
-                                || emitted;
+                emitted = emitHandler.emit(new Emit<T>(position - payload.getKeyword().length() + 1, position,
+                        payload.getKeyword(), payload.getData())) || emitted;
 
                 if (emitted && trieConfig.isStopOnHit()) {
                     break;

--- a/src/main/java/org/neosearch/stringsearcher/trie/Trie.java
+++ b/src/main/java/org/neosearch/stringsearcher/trie/Trie.java
@@ -21,11 +21,12 @@ import org.neosearch.stringsearcher.trie.util.ListElementRemoval;
 import org.neosearch.stringsearcher.trie.util.ListElementRemoval.RemoveElementPredicate;
 
 /**
- * A trie implementation, based on the Aho-Corasick white paper, Bell technologies:
- * http://cr.yp.to/bib/1975/aho.pdf
+ * A trie implementation, based on the Aho-Corasick white paper, Bell
+ * technologies: http://cr.yp.to/bib/1975/aho.pdf
  * <p>
  *
- * The payload trie adds the possibility to specify emitted payloads for each added keyword.
+ * The payload trie adds the possibility to specify emitted payloads for each
+ * added keyword.
  * 
  * @author Daniel Beck
  * @param <T> The type of the supplied of the payload
@@ -119,9 +120,10 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
         return tokens;
     }
 
-    private Token<T> createFragment(final Emit<T> emit, final String text, final int lastCollectedPosition) {
-        return new FragmentToken<T>(
-                text.substring(lastCollectedPosition + 1, emit == null ? text.length() : emit.getStart()));
+    private Token<T> createFragment(final Emit<T> emit, final String text,
+            final int lastCollectedPosition) {
+        return new FragmentToken<T>(text.substring(lastCollectedPosition + 1,
+                emit == null ? text.length() : emit.getStart()));
     }
 
     private Token<T> createMatch(Emit<T> emit, String text) {
@@ -139,14 +141,16 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
     }
 
     /**
-     * Tokenizes the specified text by using a custom EmitHandler and returns the emitted outputs.
+     * Tokenizes the specified text by using a custom EmitHandler and returns the
+     * emitted outputs.
      * 
      * @param text The character sequence to tokenize.
      * @param emitHandler The emit handler that will be used to parse the text.
      * @return A collection of emits.
      */
     @SuppressWarnings("unchecked")
-    public Collection<Emit<T>> parseText(final CharSequence text, final StatefulEmitHandler<T> emitHandler) {
+    public Collection<Emit<T>> parseText(final CharSequence text,
+            final StatefulEmitHandler<T> emitHandler) {
         parseText(text, (EmitHandler<T>) emitHandler);
 
         final List<Emit<T>> collectedEmits = emitHandler.getEmits();
@@ -155,7 +159,8 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
             removePartialMatches(text, collectedEmits);
         }
         if (!trieConfig.isAllowOverlaps()) {
-            IntervalTree intervalTree = new IntervalTree((List<Intervalable>) (List<?>) collectedEmits);
+            IntervalTree intervalTree =
+                    new IntervalTree((List<Intervalable>) (List<?>) collectedEmits);
             intervalTree.removeOverlaps((List<Intervalable>) (List<?>) collectedEmits);
         }
 
@@ -163,17 +168,20 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
     }
 
     /**
-     * Returns true if the text contains contains one of the search terms. Else, returns false.
+     * Returns true if the text contains contains one of the search terms. Else,
+     * returns false.
      * 
      * @param text Specified text.
-     * @return true if the text contains one of the search terms. Else, returns false.
+     * @return true if the text contains one of the search terms. Else, returns
+     *         false.
      */
     public boolean containsMatch(final CharSequence text) {
         return firstMatch(text) != null;
     }
 
     /**
-     * Tokenizes the specified text by using a custom EmitHandler and returns the emitted outputs.
+     * Tokenizes the specified text by using a custom EmitHandler and returns the
+     * emitted outputs.
      * 
      * @param text The character sequence to tokenize.
      * @param emitHandler The emit handler that will be used to parse the text.
@@ -228,8 +236,9 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
 
                 if (payloads != null && !payloads.isEmpty()) {
                     for (final Payload<T> payload : payloads) {
-                        final Emit<T> emit = new Emit<>(position - payload.getKeyword().length() + 1, position,
-                                payload.getKeyword(), payload.getData());
+                        final Emit<T> emit =
+                                new Emit<>(position - payload.getKeyword().length() + 1, position,
+                                        payload.getKeyword(), payload.getData());
                         if (trieConfig.isOnlyWholeWords()) {
                             if (!isPartialMatch(text, emit)) {
                                 return emit;
@@ -246,12 +255,14 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
     }
 
     private boolean isPartialMatch(final CharSequence searchText, final Emit<T> emit) {
-        return (emit.getStart() != 0 && trieConfig.isInWordCharacter().test(searchText.charAt(emit.getStart() - 1)))
-                || (emit.getEnd() + 1 != searchText.length()
-                        && trieConfig.isInWordCharacter().test(searchText.charAt(emit.getEnd() + 1)));
+        return (emit.getStart() != 0
+                && trieConfig.isInWordCharacter().test(searchText.charAt(emit.getStart() - 1)))
+                || (emit.getEnd() + 1 != searchText.length() && trieConfig.isInWordCharacter()
+                        .test(searchText.charAt(emit.getEnd() + 1)));
     }
 
-    private void removePartialMatches(final CharSequence searchText, final List<Emit<T>> collectedEmits) {
+    private void removePartialMatches(final CharSequence searchText,
+            final List<Emit<T>> collectedEmits) {
 
         final RemoveElementPredicate<Emit<T>> predicate = new RemoveElementPredicate<Emit<T>>() {
 
@@ -307,15 +318,19 @@ public class Trie<T> implements StringSearcher<T>, StringSearcherPrepare<T> {
         return this;
     }
 
-    private boolean storeEmits(final int position, final State<T> currentState, final EmitHandler<T> emitHandler) {
+    private boolean storeEmits(final int position, final State<T> currentState,
+            final EmitHandler<T> emitHandler) {
         boolean emitted = false;
         final Collection<Payload<T>> payloads = currentState.emit();
 
         // TODO: The check for empty might be superfluous.
         if (payloads != null && !payloads.isEmpty()) {
             for (final Payload<T> payload : payloads) {
-                emitted = emitHandler.emit(new Emit<T>(position - payload.getKeyword().length() + 1, position,
-                        payload.getKeyword(), payload.getData())) || emitted;
+                emitted =
+                        emitHandler
+                                .emit(new Emit<T>(position - payload.getKeyword().length() + 1,
+                                        position, payload.getKeyword(), payload.getData()))
+                                || emitted;
 
                 if (emitted && trieConfig.isStopOnHit()) {
                     break;

--- a/src/test/java/org/neosearch/stringsearcher/StringBoundaryTest.java
+++ b/src/test/java/org/neosearch/stringsearcher/StringBoundaryTest.java
@@ -1,0 +1,61 @@
+package org.neosearch.stringsearcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import java.util.Iterator;
+import java.util.function.Predicate;
+import org.junit.Test;
+
+public class StringBoundaryTest {
+
+    private final static Predicate<Character> IN_WORD_CHARACTERS =
+            ch -> Character.isAlphabetic(ch) || Character.isDigit(ch) || ch == '-' || ch == '_';
+
+    @Test
+    public void testWordBoundariesForNumbers() {
+        final String text = "Plida C2 / TELC C2 C3 and the programming language C.";
+
+        StringSearcher searcher = StringSearcher.builder().addSearchString("C")
+                .addSearchString("C2").setIsInWordCharacter(IN_WORD_CHARACTERS).build();
+        Iterator<Emit> resultIterator = searcher.parseText(text).iterator();
+        checkEmit(resultIterator.next(), 6, 7, "C2");
+        checkEmit(resultIterator.next(), 16, 17, "C2");
+        checkEmit(resultIterator.next(), 51, 51, "C");
+        assertFalse("The iterator shouldn't have found more elements", resultIterator.hasNext());
+    }
+
+    @Test
+    public void testWordBoundariesWithPunctuation() {
+        StringSearcher searcher =
+                StringSearcher.builder().addSearchString("MySQL").addSearchString("MariaDB")
+                        .addSearchString("Database").addSearchString("Database Systems")
+                        .ignoreOverlaps().setIsInWordCharacter(IN_WORD_CHARACTERS).build();
+        Iterator<Emit> resultIterator =
+                searcher.parseText("Database Systems: MariaDB;MySQL").iterator();
+        checkEmit(resultIterator.next(), 0, 15, "Database Systems");
+        checkEmit(resultIterator.next(), 18, 24, "MariaDB");
+        checkEmit(resultIterator.next(), 26, 30, "MySQL");
+        assertFalse("The iterator shouldn't have found more elements", resultIterator.hasNext());
+    }
+
+    @Test
+    public void testWordsWithSpacesAndHyphens() {
+        StringSearcher searcher = StringSearcher.builder().addSearchString("ER-Models")
+                .addSearchString("Database").addSearchString("Database Systems").ignoreOverlaps()
+                .setIsInWordCharacter(IN_WORD_CHARACTERS).build();
+        Iterator<Emit> resultIterator =
+                searcher.parseText("Knowledge of ER-Models and Database Systems:-)").iterator();
+        checkEmit(resultIterator.next(), 13, 21, "ER-Models");
+        checkEmit(resultIterator.next(), 27, 42, "Database Systems");
+        assertFalse("The iterator shouldn't have found more elements", resultIterator.hasNext());
+    }
+
+    private void checkEmit(Emit next, int expectedStart, int expectedEnd, String expectedKeyword) {
+        assertEquals("Start of emit should have been " + expectedStart, expectedStart,
+                next.getStart());
+        assertEquals("End of emit should have been " + expectedEnd, expectedEnd, next.getEnd());
+        assertEquals("Keyword of emit shoud be " + expectedKeyword, expectedKeyword,
+                next.getSearchString());
+    }
+
+}


### PR DESCRIPTION
This pull request allows specifying custom in-word characters for words by extending `isPartialMatch` in `Trie.java`, which improves the libraries flexibility in defining word boundaries.

**Example:**

```java
// create a searcher that allows numbers and hyphens in words.
StringSearcher searcher = StringSearcher.builder().addSearchString("ER-Models")
                .addSearchString("Database").addSearchString("C2")
                .setIsInWordCharacter(ch -> Character.isAlphabetic(ch) || Character.isDigit(ch) || ch == '-').build();
```

Both the currently used `onlyWholeWordsWhiteSpaceSeparated` and `onlyWholeWords` flags can be expressed with a corresponding `inWordCharacter`expression. 
=> `StringSearcherConfig.java` has been adapted to continue supporting both flags as well.